### PR TITLE
Github-toggle-expanders: handle PR comments

### DIFF
--- a/github-toggle-expanders.user.js
+++ b/github-toggle-expanders.user.js
@@ -19,8 +19,9 @@
 			.classList.contains("open"),
 			// target buttons inside commits_bucket - fixes #8
 			selectors = `
-				.commits-listing .commits-list-item,
 				#commits_bucket .js-details-container,
+				.commits-listing .commits-list-item,
+				.discussion-item-body .js-details-container,
 				.release-timeline-tags .js-details-container`;
 		Array.from(document.querySelectorAll(selectors)).forEach(el => {
 			el.classList.toggle("open", state);
@@ -39,10 +40,10 @@
 
 	document.body.addEventListener("click", event => {
 		const target = event.target;
-		if (
-			target && event.getModifierState("Shift") &&
-			target.matches(".ellipsis-expander")
-		) {
+		if (target && event.getModifierState("Shift") && (
+			target.matches(".ellipsis-expander") ||
+			target.matches(".js-details-target")
+		)) {
 			// give GitHub time to add the class
 			setTimeout(() => {
 				toggle(target);


### PR DESCRIPTION
I have chosen to handle the click only for the current review,
not all reviews done in the PR wich could be too much
(and less interesting from my use case -> check everything is OK for one review)

So the selector is `..discussion-item-body` and not `.js-discussion`