### PR TITLE
(GitHub Label Color Picker) Restore functionality due to recent GitHub layout changes

### DIFF
--- a/github-label-color-picker.user.js
+++ b/github-label-color-picker.user.js
@@ -1,9 +1,10 @@
 // ==UserScript==
 // @name        GitHub Label Color Picker
-// @version     1.0.4
+// @version     1.0.5
 // @description A userscript that adds a color picker to the label color input
 // @license     MIT
 // @author      Rob Garrison
+// @contributor darkred
 // @namespace   https://github.com/Mottie
 // @include     https://github.com/*
 // @run-at      document-idle
@@ -13,24 +14,22 @@
 // @grant       GM_registerMenuCommand
 // @require     https://greasyfork.org/scripts/23181-colorpicker/code/colorPicker.js?version=147862
 // @icon        https://assets-cdn.github.com/pinned-octocat.svg
-// @updateURL   https://raw.githubusercontent.com/Mottie/GitHub-userscripts/master/github-label-color-picker.user.js
-// @downloadURL https://raw.githubusercontent.com/Mottie/GitHub-userscripts/master/github-label-color-picker.user.js
 // ==/UserScript==
 (() => {
 	"use strict";
 
-	GM_addStyle("div.cp-app { margin-top:65px; z-index:10; }");
+	GM_addStyle("div.cp-app { margin-top:110px; z-index:10; }");
 
 	function addPicker() {
-		if (document.querySelector(".js-color-editor")) {
-			jsColorPicker(".js-color-editor-input", {
+		if (document.querySelector(".js-new-label-color")) {
+			jsColorPicker(".js-new-label-color-input", {
 				customBG: "#222",
 				noAlpha: true,
 				renderCallback: function(colors) {
 					let input = this && this.input;
 					if (input) {
 						input.value = "#" + colors.HEX;
-						input.previousElementSibling.style.backgroundColor = input.value;
+						input.parentNode.previousElementSibling.style.backgroundColor = input.value;
 					}
 				}
 			});

--- a/github-label-color-picker.user.js
+++ b/github-label-color-picker.user.js
@@ -18,7 +18,7 @@
 (() => {
 	"use strict";
 
-	GM_addStyle("div.cp-app { margin-top:110px; z-index:10; }");
+	GM_addStyle("div.cp-app { margin-top:110px; margin-left:-8px; z-index:10; }");
 
 	function addPicker() {
 		if (document.querySelector(".js-new-label-color")) {

--- a/github-label-color-picker.user.js
+++ b/github-label-color-picker.user.js
@@ -14,6 +14,8 @@
 // @grant       GM_registerMenuCommand
 // @require     https://greasyfork.org/scripts/23181-colorpicker/code/colorPicker.js?version=147862
 // @icon        https://assets-cdn.github.com/pinned-octocat.svg
+// @updateURL   https://raw.githubusercontent.com/Mottie/GitHub-userscripts/master/github-label-color-picker.user.js
+// @downloadURL https://raw.githubusercontent.com/Mottie/GitHub-userscripts/master/github-label-color-picker.user.js
 // ==/UserScript==
 (() => {
 	"use strict";


### PR DESCRIPTION
Restore functionality due to recent GitHub layout changes.

@Mottie 
there was a small misalignment (few pixels wide) between the color swatch and the created color picker:
![2018-05-16_212948](https://user-images.githubusercontent.com/723651/40137020-192b9e78-5952-11e8-937e-ada0e3bc95bd.jpg)
hence the extra rule: `margin-left:-8px;`. I hope you're fine with that.