### PR TITLE
Fix tabs evaluate to 7 spaces instead of 8

### DIFF
--- a/github-remove-diff-signs.user.js
+++ b/github-remove-diff-signs.user.js
@@ -18,7 +18,7 @@
 
 	GM_addStyle(`.diff-table .blob-code-inner:before {
 		user-select: none;
-		content: "\\a0";
+		content: "";
 	}`);
 
 	function processDiff() {


### PR DESCRIPTION
Change to empty content instead of \a0.

Tested on Chrome 68