### PR TITLE
Support Cmd + Shift + Click for Macs

### DIFF
--- a/github-toggle-expanders.user.js
+++ b/github-toggle-expanders.user.js
@@ -47,7 +47,7 @@
 		) {
 			// give GitHub time to add the class
 			setTimeout(() => {
-				toggle(target, event.ctrlKey);
+				toggle(target, event.ctrlKey || event.metaKey);
 			}, 100);
 		}
 	});


### PR DESCRIPTION
Tested in Chrome 68 on a MacBookPro14,3 running macOS 10.12.6.