### PR TITLE
Issue-comments: strikethrough applied filter names

### DIFF
--- a/github-issue-comments.user.js
+++ b/github-issue-comments.user.js
@@ -31,10 +31,10 @@
 		.ghic-button .dropdown-item { font-weight:normal; position:relative; }
 		.ghic-button .dropdown-item span { font-weight:normal; opacity:.5; }
 		.ghic-button .dropdown-item.ghic-has-content span { opacity:1; }
-		.dropdown-item.ghic-has-content:not(.ghic-checked){ text-decoration:line-through; }
 		.ghic-button .dropdown-item.ghic-checked span { font-weight:bold; }
 		.ghic-button .dropdown-item.ghic-checked svg,
 			.ghic-button .dropdown-item:not(.ghic-checked) .ghic-count { display:inline-block; }
+		.ghic-button .dropdown-item:not(.ghic-checked) { text-decoration:line-through; }
 		.ghic-button .ghic-count { margin-left:5px; }
 		.ghic-button .select-menu-modal { margin:0; }
 		.ghic-button .ghic-participants { margin-bottom:20px; }

--- a/github-issue-comments.user.js
+++ b/github-issue-comments.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        GitHub Toggle Issue Comments
-// @version     1.3.2
+// @version     1.3.3
 // @description A userscript that toggles issues/pull request comments & messages
 // @license     MIT
 // @author      Rob Garrison
@@ -31,6 +31,7 @@
 		.ghic-button .dropdown-item { font-weight:normal; position:relative; }
 		.ghic-button .dropdown-item span { font-weight:normal; opacity:.5; }
 		.ghic-button .dropdown-item.ghic-has-content span { opacity:1; }
+		.dropdown-item.ghic-has-content:not(.ghic-checked){ text-decoration: line-through; }
 		.ghic-button .dropdown-item.ghic-checked span { font-weight:bold; }
 		.ghic-button .dropdown-item.ghic-checked svg,
 			.ghic-button .dropdown-item:not(.ghic-checked) .ghic-count { display:inline-block; }

--- a/github-issue-comments.user.js
+++ b/github-issue-comments.user.js
@@ -31,7 +31,7 @@
 		.ghic-button .dropdown-item { font-weight:normal; position:relative; }
 		.ghic-button .dropdown-item span { font-weight:normal; opacity:.5; }
 		.ghic-button .dropdown-item.ghic-has-content span { opacity:1; }
-		.dropdown-item.ghic-has-content:not(.ghic-checked){ text-decoration: line-through; }
+		.dropdown-item.ghic-has-content:not(.ghic-checked){ text-decoration:line-through; }
 		.ghic-button .dropdown-item.ghic-checked span { font-weight:bold; }
 		.ghic-button .dropdown-item.ghic-checked svg,
 			.ghic-button .dropdown-item:not(.ghic-checked) .ghic-count { display:inline-block; }


### PR DESCRIPTION
Better distinguish the filters that are being applied, by using a strike-through on the applied filter names.

I hope you like my suggestion, @Mottie 🙂 

Animated screen capture comparison:

<details>
<summary>Currently:</summary> 

![12345](https://user-images.githubusercontent.com/723651/46423399-20164e80-c73f-11e8-8017-2679901ef3e7.gif)
</details>

<details><summary>My suggested change:</summary> 

![12345](https://user-images.githubusercontent.com/723651/46423102-746cfe80-c73e-11e8-986d-b879a4709483.gif)
</details>
 