### PR TITLE
github-files-filter : strikethrough applied filter names

### DIFF
--- a/github-files-filter.user.js
+++ b/github-files-filter.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        GitHub Files Filter
-// @version     1.1.4
+// @version     1.1.5
 // @description A userscript that adds filters that toggle the view of repo files by extension
 // @license     MIT
 // @author      Rob Garrison
@@ -22,6 +22,9 @@
 	// animation delay; See #46
 	GM_addStyle(`
 		.gff-filter .btn.selected { font-variant: small-caps; }
+		.gff-filter .btn:not(.selected):not(:first-child) {
+      			text-decoration: line-through;
+		}
 		.gff-filter .gff-all:not(.selected):focus,
 		.gff-filter .gff-all:not(.selected) ~ .btn:focus,
 		.gff-filter .gff-all:not(.selected) ~ .btn.selected:focus,


### PR DESCRIPTION
In continuation to your commit in https://github.com/Mottie/GitHub-userscripts/issues/46 i.e. changing the capitalization as you toggle the filters,
my suggested addition is to also add **strikethrough** to the toggled filters _<sup>(like in my PR https://github.com/Mottie/GitHub-userscripts/pull/59 for 'Toggle Issue Comments')</sup>_ The reason is because I was still finding it difficult to distinguish which filters are disabled.

Screenshot comparison:

<details>
<summary>Before</summary>

![1](https://user-images.githubusercontent.com/723651/51041986-ccc85d80-15c3-11e9-8f70-d2a065b1a54a.gif)
</details>

<details>
<summary>After</summary>

![2](https://user-images.githubusercontent.com/723651/51041985-ccc85d80-15c3-11e9-8ea2-94a1c564e845.gif)
</details>

&nbsp;

I hope you like my suggestion, @Mottie 🙂 