### PR TITLE
Fix for Github Download Zip stopped working due to GH changes #72

### DIFF
--- a/github-download-zip.user.js
+++ b/github-download-zip.user.js
@@ -35,7 +35,7 @@
 
 	function updateLinks() {
 		// Branch dropdown on main repo page
-		const branch = $("button[data-hotkey='w'] span");
+		const branch = $("summary[data-hotkey='w'] span");
 		// Download link in "Clone or Download" dropdown
 		const downloadLink = $("a[data-ga-click*='download zip']");
 		// Repo commits page


### PR DESCRIPTION
Fix for Github Download Zip stopped working due to GH changes #72