### PR TITLE
Custom-hotkeys: Add "{branch}" and "{commit}"

### DIFF
--- a/github-custom-hotkeys.user.js
+++ b/github-custom-hotkeys.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        GitHub Custom Hotkeys
-// @version     1.0.24
+// @version     1.0.25
 // @description A userscript that allows you to add custom GitHub keyboard hotkeys
 // @license     MIT
 // @author      Rob Garrison
@@ -133,6 +133,16 @@
 		if (parts.t === "issues" || parts.t === "pulls") {
 			// issue number
 			parts.issue = tmp[4] || "";
+		}
+		// branch/tag?
+		if (parts.t === "tree" || parts.t === "blob") {
+			parts.branch = tmp[4] || "";
+		} else if (parts.t === "releases" && tmp[4] === "tag") {
+			parts.branch = tmp[5] || "";
+		}
+		// commit hash?
+		if (parts.t === "commit") {
+			parts.commit = tmp[4] || "";
 		}
 		// forked from
 		tmp = $(".repohead .fork-flag a");


### PR DESCRIPTION
I originally came across this script on search looking for a way to add a hotkey to compare the current branch/tag to the `master` (or other branch). Unfortunately, it does not currently support this, so here it is!

This PR will allow you to easily add a hotkey to compare the current branch/tag/commit to a static branch, for example `master`:
```
{
  "all": [
    { "f1": "#hotkey-settings" },
    { "c m": "{repo}/compare/{branch}...master" },
    { "c m": "{repo}/compare/{commit}...master" }
  ]
}
```

There are a couple of pages where this hotkey is useful:
- https://github.com/Mottie/GitHub-userscripts/tree/v1.0.230
- https://github.com/Mottie/GitHub-userscripts/blob/v1.0.230/README.md
- https://github.com/Mottie/GitHub-userscripts/releases/tag/v1.0.230
- https://github.com/Mottie/GitHub-userscripts/commit/8bfc99570695da6f3683e19aeafcb0cb28f26032

I have tested the hotkey `c m` on a few pages, and it doesn't seem to conflict on any pages that you would intentionally use this hotkey on. The only pages I have found that use the hotkey `c` are:
- https://github.com/Mottie/GitHub-userscripts/issues (create new issue)
- https://github.com/Mottie/GitHub-userscripts/pulls (takes you to `/compare` page)
- https://github.com/Mottie/GitHub-userscripts/commits/master (opens selected commit)