### PR TITLE
Add support for sorting GitHub checks

### DIFF
--- a/github-sort-content.user.js
+++ b/github-sort-content.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        GitHub Sort Content
-// @version     3.1.1
+// @version     3.2.0
 // @description A userscript that makes some lists & markdown tables sortable
 // @license     MIT
 // @author      Rob Garrison
@@ -407,6 +407,33 @@
 					".ghsc-gazer-header"
 				]
 			}
+		},
+		// github.com/(:user|:org)/:repo/pull/:pr
+		"pull-request-checks": {
+			check: el => el.matches(".merge-status-list"),
+			sort: el => {
+				removeSelection();
+				tinysort(
+					$$("div.merge-status-item"),
+					// first by status
+					{
+						order: 'asc',
+						selector: 'path',
+						attr: 'd'
+					},
+					// then by check name
+					{
+						order: 'asc',
+						natural: true,
+						selector: `strong.text-emphasized`
+					}
+				)
+			},
+			css: {
+				unsorted: [
+					".merge-status-list"
+				]
+			}
 		}
 	};
 
@@ -521,6 +548,13 @@
 		setDirection($$(".ghsc-header-cell", grid), el, dir);
 	}
 
+	/**
+	 *
+	 * @param {*} header The element containing the header
+	 * @param {*} list The element containing the list
+	 * @param {*} opts Options passed to tinysort. See <a href="http://tinysort.sjeiti.com/">TinySort</a> for details.
+	 *                 Multiple selectors have to be passed using a single selector with an appropriate query, e.g. <code>{ selector: "a[id], a.f4" }</code>
+	 */
 	function initSortList(header, list, opts = {}) {
 		if (list) {
 			removeSelection();


### PR DESCRIPTION
When having hundreds of tests, it is difficult to switch to the failing ones.

Example:

![grafik](https://user-images.githubusercontent.com/1366654/101262258-80e5ab00-373d-11eb-9d1d-449d3bf4cf3a.png)

My solution proposal:  Sort the list of check outputs by "priority": failing, running, queued, cancelled. Therein by name. This is done with this PR (accepting that currently the status is more or less randomly sorted).

After applying this PR:

![grafik](https://user-images.githubusercontent.com/1366654/101266548-e93d8800-374f-11eb-8389-24051efc992b.png)

I also increase the "minor" version, because a new functionality is added with this PR.

Alternatively, a filter showing the failing tests only would be helpful, too.

Fixes https://github.com/sindresorhus/refined-github/issues/3791

After a merge, https://github.com/Mottie/GitHub-userscripts/wiki/GitHub-sort-content neesd to be updated.