### PR TITLE
Revise browser extension links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,9 @@ Userscripts to add functionality to GitHub.
 
 1. Make sure you have user scripts enabled in your browser (these instructions refer to the latest versions of the browser):
 
-	* Firefox - install [Tampermonkey](https://tampermonkey.net/?ext=dhdg&browser=firefox), [Greasemonkey](https://addons.mozilla.org/firefox/addon/greasemonkey/) (GM v4+ is **not supported**!) or [Violentmonkey](https://violentmonkey.github.io/get-it/).
-	* Chrome - install [Tampermonkey](https://tampermonkey.net/?ext=dhdg&browser=chrome) or [Violentmonkey](https://violentmonkey.github.io/get-it/).
-	* Opera - install [Tampermonkey](https://tampermonkey.net/?ext=dhdg&browser=opera) or [Violentmonkey](https://violentmonkey.github.io/get-it/).
-	* Safari - install [Tampermonkey](https://tampermonkey.net/?ext=dhdg&browser=safari).
-	* Dolphin - install [Tampermonkey](https://tampermonkey.net/?ext=dhdg&browser=dolphin).
-	* UC Browser - install [Tampermonkey](https://tampermonkey.net/?ext=dhdg&browser=ucweb).
+	* [Tampermonkey](https://www.tampermonkey.net/) (proprietary)
+	* [Violentmonkey](https://violentmonkey.github.io/get-it/)
+	* [Greasemonkey](https://addons.mozilla.org/firefox/addon/greasemonkey/) (**version since 4.0 is not supported**!)
 
 2. Get information or install:
 	* Learn more about the userscript by clicking on the named link. You will be taken to the specific wiki page.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Userscripts to add functionality to GitHub.
 
 1. Make sure you have user scripts enabled in your browser (these instructions refer to the latest versions of the browser):
 
-	* Firefox - install [Tampermonkey](https://tampermonkey.net/?ext=dhdg&browser=firefox), [Greasemonkey](https://addons.mozilla.org/firefox/addon/greasemonkey/) (GM v4+ is **not supported**!) or [Violentmonkey](https://addons.mozilla.org/firefox/addon/violentmonkey/).
-	* Chrome - install [Tampermonkey](https://tampermonkey.net/?ext=dhdg&browser=chrome) or [Violentmonkey](https://chrome.google.com/webstore/detail/violentmonkey/jinjaccalgkegednnccohejagnlnfdag).
-	* Opera - install [Tampermonkey](https://tampermonkey.net/?ext=dhdg&browser=opera) or [Violentmonkey](https://chrome.google.com/webstore/detail/violentmonkey/jinjaccalgkegednnccohejagnlnfdag).
+	* Firefox - install [Tampermonkey](https://tampermonkey.net/?ext=dhdg&browser=firefox), [Greasemonkey](https://addons.mozilla.org/firefox/addon/greasemonkey/) (GM v4+ is **not supported**!) or [Violentmonkey](https://violentmonkey.github.io/get-it/).
+	* Chrome - install [Tampermonkey](https://tampermonkey.net/?ext=dhdg&browser=chrome) or [Violentmonkey](https://violentmonkey.github.io/get-it/).
+	* Opera - install [Tampermonkey](https://tampermonkey.net/?ext=dhdg&browser=opera) or [Violentmonkey](https://violentmonkey.github.io/get-it/).
 	* Safari - install [Tampermonkey](https://tampermonkey.net/?ext=dhdg&browser=safari).
 	* Dolphin - install [Tampermonkey](https://tampermonkey.net/?ext=dhdg&browser=dolphin).
 	* UC Browser - install [Tampermonkey](https://tampermonkey.net/?ext=dhdg&browser=ucweb).

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Userscripts to add functionality to GitHub.
 
 1. Make sure you have user scripts enabled in your browser (these instructions refer to the latest versions of the browser):
 
-	* Firefox - install [Tampermonkey](https://tampermonkey.net/?ext=dhdg&browser=firefox) or [Greasemonkey](https://addons.mozilla.org/en-US/firefox/addon/greasemonkey/) (GM v4+ is **not supported**!).
-	* Chrome - install [Tampermonkey](https://tampermonkey.net/?ext=dhdg&browser=chrome).
-	* Opera - install [Tampermonkey](https://tampermonkey.net/?ext=dhdg&browser=opera) or [Violent Monkey](https://addons.opera.com/en/extensions/details/violent-monkey/).
+	* Firefox - install [Tampermonkey](https://tampermonkey.net/?ext=dhdg&browser=firefox), [Greasemonkey](https://addons.mozilla.org/firefox/addon/greasemonkey/) (GM v4+ is **not supported**!) or [Violentmonkey](https://addons.mozilla.org/firefox/addon/violentmonkey/).
+	* Chrome - install [Tampermonkey](https://tampermonkey.net/?ext=dhdg&browser=chrome) or [Violentmonkey](https://chrome.google.com/webstore/detail/violentmonkey/jinjaccalgkegednnccohejagnlnfdag).
+	* Opera - install [Tampermonkey](https://tampermonkey.net/?ext=dhdg&browser=opera) or [Violentmonkey](https://chrome.google.com/webstore/detail/violentmonkey/jinjaccalgkegednnccohejagnlnfdag).
 	* Safari - install [Tampermonkey](https://tampermonkey.net/?ext=dhdg&browser=safari).
 	* Dolphin - install [Tampermonkey](https://tampermonkey.net/?ext=dhdg&browser=dolphin).
 	* UC Browser - install [Tampermonkey](https://tampermonkey.net/?ext=dhdg&browser=ucweb).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Userscripts to add functionality to GitHub.
 
 	* [Tampermonkey](https://www.tampermonkey.net/) (proprietary)
 	* [Violentmonkey](https://violentmonkey.github.io/get-it/)
-	* [Greasemonkey](https://addons.mozilla.org/firefox/addon/greasemonkey/) (**version since 4.0 is not supported**!)
+	* [Greasemonkey](https://addons.mozilla.org/firefox/addon/greasemonkey/) (some scripts are **not compatible with Greasemonkey 4**!)
 
 2. Get information or install:
 	* Learn more about the userscript by clicking on the named link. You will be taken to the specific wiki page.


### PR DESCRIPTION
I noticed the link to Violentmonkey in Opera is broken so I fixed it. I also added Violentmonkey links to Firefox and Chrome, hope you don't mind.

I have an additional request: would you mind putting Tampermonkey after Greasemonkey and Violentmonkey, since it is no longer open source? I believe we developers on GitHub are more concerned about this aspect.