### PR TITLE
Disable GitHub Copy Code Snippet on main site

### DIFF
--- a/github-copy-code-snippet.user.js
+++ b/github-copy-code-snippet.user.js
@@ -1,11 +1,10 @@
 // ==UserScript==
 // @name        GitHub Copy Code Snippet
-// @version     0.3.8
+// @version     0.3.9
 // @description A userscript adds a copy to clipboard button on hover of markdown code snippets
 // @license     MIT
 // @author      Rob Garrison
 // @namespace   https://github.com/Mottie
-// @include     https://github.com/*
 // @include     https://gist.github.com/*
 // @run-at      document-idle
 // @grant       GM_addStyle


### PR DESCRIPTION
[GitHub has natively added this](https://twitter.com/natfriedman/status/1391862005095485440) more than half a year ago, and currently the script duplicates with it:

<img width="744" alt="image" src="https://user-images.githubusercontent.com/44045911/155523952-d0d21511-e8ee-42ad-996a-428894936422.png">

It seems by "all code blocks on GitHub" they do mean `github.com` (as I haven't seen one code block without the native copy button), but not `gist.github.com`, so this script does not become entirely deprecated 😛