### PR TITLE
Github Code Colors - Fix GitHub domains include

### DIFF
--- a/github-code-colors.user.js
+++ b/github-code-colors.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        GitHub Code Colors
-// @version     2.0.8
+// @version     2.0.9
 // @description A userscript that adds a color swatch next to the code color definition
 // @license     MIT
 // @author      Rob Garrison

--- a/github-code-colors.user.js
+++ b/github-code-colors.user.js
@@ -5,7 +5,8 @@
 // @license     MIT
 // @author      Rob Garrison
 // @namespace   https://github.com/Mottie
-// @include     https://*.github.com/*
+// @match       https://github.com/*
+// @match       https://gist.github.com/*
 // @run-at      document-idle
 // @grant       GM.addStyle
 // @grant       GM_addStyle


### PR DESCRIPTION
There was a rule that only included GitHub subdomains:
`// @include     https://*.github.com/*`

Due this, the script only worked with gists. This PR includes the `github.com` domain (as in other scripts) and fixes this issue.