### PR TITLE
Automate expanding of all comments on a PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Userscripts to add functionality to GitHub.
 	| [GitHub unknown license][gul-wiki]     |     | [install][gul-raw] | [GF][gul-gf] [OU][gul-ou] | 2020.03.29 | 2022.10.24 |
 	| [GitHub update fork][ufk-wiki]         |     | [install][ufk-raw] | [GF][ufk-gf] [OU][ufk-ou] | 2020.02.16 | 2020.10.01 |
 	| [GitHub watcher][wat-wiki]             |     | [install][wat-raw] | [GF][wat-gf] [OU][wat-ou] | 2021.02.28 | 2022.10.24 |
+	| [GitHub expand PR comments][exp-wiki]  |     | [install][exp-raw] |  | 2023.10.12 | 2023.10.12 |
 	| [Gist raw links][grl-wiki]             |     | [install][grl-raw] | [GF][grl-gf] [OU][grl-ou] | 2017.05.19 | 2019.06.07 |
 	| [Gist to dabblet][g2d-wiki]            |     | [install][g2d-raw] | [GF][g2d-gf] [OU][g2d-ou] | 2012.01.26 | 2017.02.16 |
 
@@ -117,6 +118,7 @@ Userscripts to add functionality to GitHub.
 [tws-wiki]: https://github.com/Mottie/GitHub-userscripts/wiki/GitHub-toggle-wiki-sidebar
 [ufk-wiki]: https://github.com/Mottie/GitHub-userscripts/wiki/GitHub-update-fork
 [wat-wiki]: https://github.com/Mottie/GitHub-userscripts/wiki/GitHub-watcher
+[exp-wiki]: https://github.com/Mottie/GitHub-userscripts/wiki/Github-expand-pr-comments
 
 [ccr-raw]: https://raw.githubusercontent.com/Mottie/GitHub-userscripts/master/github-code-colors.user.js
 [ccs-raw]: https://raw.githubusercontent.com/Mottie/GitHub-userscripts/master/github-copy-code-snippet.user.js
@@ -164,6 +166,7 @@ Userscripts to add functionality to GitHub.
 [tws-raw]: https://raw.githubusercontent.com/Mottie/GitHub-userscripts/master/github-toggle-wiki-sidebar.user.js
 [ufk-raw]: https://raw.githubusercontent.com/Mottie/GitHub-userscripts/master/github-update-fork.user.js
 [wat-raw]: https://raw.githubusercontent.com/Mottie/GitHub-userscripts/master/github-watcher.user.js
+[exp-raw]: https://raw.githubusercontent.com/Mottie/GitHub-userscripts/master/github-expand-pr-comments.user.js
 
 [ccr-gf]: https://greasyfork.org/en/scripts/18141-github-code-colors
 [ccs-gf]: https://greasyfork.org/en/scripts/37307-github-copy-code-snippet

--- a/github-expand-pr-comments.user.js
+++ b/github-expand-pr-comments.user.js
@@ -1,0 +1,143 @@
+// ==UserScript==
+// @name        Expand all PR comments
+// @version     1.0.0
+// @description Add a button "Expand" which expands automatically all comments on the PR page marked with "hidden items" or "hidden conversations" and initially requiring iterative manual clicking.
+// @license     MIT
+// @author      Konstantin Knyazkov
+// @homepage    https://github.com/ze0n
+// @namespace   https://github.com/Mottie
+// @match       https://github.com/*/*/pull/*
+// @icon        https://github.githubassets.com/pinned-octocat.svg
+// @grant       none
+// @supportURL  https://github.com/Mottie/GitHub-userscripts/issues
+// @updateURL   https://raw.githubusercontent.com/Mottie/GitHub-userscripts/master/github-expand-pr-comments.user.js
+// @downloadURL https://raw.githubusercontent.com/Mottie/GitHub-userscripts/master/github-expand-pr-comments.user.js
+// ==/UserScript==
+
+(function() {
+    'use strict';
+
+	const ButtonPlacement = {
+		LeftFixed: "leftFixed",
+		RightSidebar: "rightSidebar",
+	}
+
+	const AfterExpandedBehavior = {
+		RemoveButton: "removeButton",
+		ExpandedText: "expandedText"
+	}
+
+	// Constants
+	const DEBUG = false; // console logging on/off
+	const sideBarGithubId = "partial-discussion-sidebar";
+	const buttonGithubClassName = "btn";
+	const buttonPlaceMode = ButtonPlacement.RightSidebar;
+	const afterExpandMode = AfterExpandedBehavior.ExpandedText;
+	const expandButtonId = "_ExpandAllCommentsBtnId";
+	const expandButtonExpandText = "Expand all comments";
+	const expandButtonExpandedText = "Expanded";
+	const expandingButtonExpandedText = "Expanding...";
+    const defaultNumberOffRetriesWithoutEffectBeforeStop = 5;
+    const intervalBetweenRetriesMs = 2000;
+
+    function expandAllButtonsRecursive(notEffectiveRetriesLeftToDo, accumulatingNumberOfExpandedFragments)
+    {
+        const expandButton = document.getElementById(expandButtonId);
+
+		if(DEBUG){
+			console.log(expandButton);
+		}
+
+        if(notEffectiveRetriesLeftToDo === 0){
+			// Done
+			if(afterExpandMode === AfterExpandedBehavior.ExpandedText){
+				expandButton.innerHTML = expandButtonExpandedText;
+			}else if(afterExpandMode === AfterExpandedBehavior.RemoveButton){
+				expandButton.display = "none";
+			}
+        }
+		else if(notEffectiveRetriesLeftToDo > 0) {
+			// Continue expanding
+            expandButton.innerHTML = expandingButtonExpandedText + " (" + accumulatingNumberOfExpandedFragments + ")";
+            expandButton.disabled = true;
+        }
+
+		// Find all visible fragments to expand
+        const buttons1 = document.evaluate("//button[contains(normalize-space(text()), 'hidden items')]", document, null, XPathResult.ANY_TYPE, null );
+        const buttons2 = document.evaluate("//button[contains(normalize-space(text()), 'hidden conversations')]", document, null, XPathResult.ANY_TYPE, null );
+        const allButtons = [];
+
+		let cur;
+        while(cur = buttons1.iterateNext()){
+            allButtons.push(cur);
+        }
+        while(cur = buttons2.iterateNext()){
+            allButtons.push(cur);
+        }
+
+        let numberOfExpandedFragmentsOnIteration = 0;
+        let updatedNotEffectiveRetriesLeftToDo = notEffectiveRetriesLeftToDo;
+
+		allButtons.forEach((currentButton)=>{
+            if(DEBUG){
+				console.log(currentButton);
+			}
+            currentButton.click(); // Emulate click to expand a fragment
+            numberOfExpandedFragmentsOnIteration ++;
+            return 1;
+        })
+
+        let isNextIterationNeeded = true;
+        if(numberOfExpandedFragmentsOnIteration > 0){
+            updatedNotEffectiveRetriesLeftToDo = defaultNumberOffRetriesWithoutEffectBeforeStop;
+        }else if(numberOfExpandedFragmentsOnIteration == 0 && updatedNotEffectiveRetriesLeftToDo > 0){
+            updatedNotEffectiveRetriesLeftToDo --;
+        }else if(numberOfExpandedFragmentsOnIteration == 0 && updatedNotEffectiveRetriesLeftToDo == 0){
+            isNextIterationNeeded = false;
+        }
+
+        if(isNextIterationNeeded){
+            setTimeout(expandAllButtonsRecursive, intervalBetweenRetriesMs, updatedNotEffectiveRetriesLeftToDo, accumulatingNumberOfExpandedFragments+numberOfExpandedFragmentsOnIteration);
+        }
+    }
+
+    function addExpandButton(buttonText, onclick) {
+		let cssObj = {};
+
+		if(buttonPlaceMode === ButtonPlacement.LeftFixed){
+			cssObj = {position: 'fixed', top: '150px', left:'30px', 'z-index': 3};
+		}
+
+        let button = document.createElement('button'), btnStyle = button.style;
+        document.body.appendChild(button);
+        button.innerHTML = buttonText;
+        button.id = expandButtonId;
+        button.onclick = onclick;
+        Object.keys(cssObj).forEach(key => {btnStyle[key] = cssObj[key]; return 1;});
+        button.className = buttonGithubClassName;
+
+		if(buttonPlaceMode === ButtonPlacement.RightSidebar)
+		{
+			const sideBar = document.getElementById(sideBarGithubId);
+			let container = document.createElement('div')
+			container.className = "discussion-sidebar-item";
+			sideBar.appendChild(container);
+			container.appendChild(button);
+		}
+
+		return button;
+    }
+
+    function expandButtonClickFunction() {
+        expandAllButtonsRecursive(defaultNumberOffRetriesWithoutEffectBeforeStop, 0);
+    }
+
+    window.addEventListener('load', () => {
+        const btn = addExpandButton(expandButtonExpandText, expandButtonClickFunction);
+
+		if(DEBUG){
+			console.log("Expand button has been added", btn);
+		}
+    })
+
+})();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "github-userscripts",
-	"version": "1.0.304",
+	"version": "1.0.305",
 	"description": "Userscripts to add functionality to GitHub",
 	"license": "MIT",
 	"repository": "Mottie/GitHub-userscripts",


### PR DESCRIPTION
## Motivation
Reviewing large PRs in github is complicated by the need to unfold each time the comments by iteratively clicking on the buttons "N hidden items" or "N hidden conversations":
![image](https://github.com/Mottie/GitHub-userscripts/assets/54500/bc57a076-02af-44d0-9058-094300f1d6db)

## States
### State before expand
Button is available on the right sidebar:
![image](https://github.com/Mottie/GitHub-userscripts/assets/54500/2b6149b1-2436-45d8-b5f1-f02c454a21e3)

### State expanding
Button is disabled and showing the process (integer = number of unfolds)
![image](https://github.com/Mottie/GitHub-userscripts/assets/54500/b70954a1-83be-48f3-b243-895b8c7bf895)

### State expanded
Button is disabled
![image](https://github.com/Mottie/GitHub-userscripts/assets/54500/2c95e55d-aa99-43b0-8611-a8130bf8e0c3)
