### PR TITLE
feat: expand toggle-wiki-sidebar

### DIFF
--- a/github-toggle-sidebar.user.js
+++ b/github-toggle-sidebar.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name        GitHub Toggle Wiki Sidebar
+// @name        GitHub Toggle Sidebar
 // @version     1.1.3
 // @description A userscript that adds a button to toggle the GitHub sidebar (repo and wiki pages)
 // @license     MIT
@@ -13,8 +13,8 @@
 // @require     https://greasyfork.org/scripts/28721-mutations/code/mutations.js?version=1108163
 // @require     https://greasyfork.org/scripts/398877-utils-js/code/utilsjs.js?version=1079637
 // @icon        https://github.githubassets.com/pinned-octocat.svg
-// @updateURL   https://raw.githubusercontent.com/Mottie/GitHub-userscripts/master/github-toggle-wiki-sidebar.user.js
-// @downloadURL https://raw.githubusercontent.com/Mottie/GitHub-userscripts/master/github-toggle-wiki-sidebar.user.js
+// @updateURL   https://raw.githubusercontent.com/Mottie/GitHub-userscripts/master/github-toggle-sidebar.user.js
+// @downloadURL https://raw.githubusercontent.com/Mottie/GitHub-userscripts/master/github-toggle-sidebar.user.js
 // @supportURL  https://github.com/Mottie/GitHub-userscripts/issues
 // ==/UserScript==
 

--- a/github-toggle-sidebar.user.js
+++ b/github-toggle-sidebar.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        GitHub Toggle Wiki Sidebar
 // @version     1.1.3
-// @description A userscript that adds a button to toggle the GitHub Wiki sidebar
+// @description A userscript that adds a button to toggle the GitHub sidebar (repo and wiki pages)
 // @license     MIT
 // @author      Rob Garrison
 // @namespace   https://github.com/Mottie
@@ -39,8 +39,7 @@
 		</svg>`;
 
 	function addToggle() {
-		if ($("#wiki-wrapper") && !$(".ghtws-button")) {
-			let el = $(".gh-header-actions") || $(".gh-header-title");
+		if (($("#wiki-wrapper") || ($("#repository-container-header"))) && !$(".ghtws-button")) {
 			const button = make({
 				el: "button",
 				className: `btn btn-sm tooltipped tooltipped-s ghtws-button${isHidden ? " selected" : ""}`,
@@ -50,13 +49,22 @@
 					"aria-label": "Toggle Sidebar"
 				}
 			});
-			if (el.nodeName === "H1") {
-				// non-editable wiki pages
-				button.style.float = "right";
-				el = el.parentNode;
+
+			let container = $(".pagehead-actions");
+			if (!container) {
+				let el = $(".gh-header-actions") || $(".gh-header-title");
+				if (el) {
+					container = make({
+						el: "ul",
+						className: "pagehead-actions flex-shrink-0 d-none d-md-inline",
+						style: "padding: 2px 0;"
+					})
+					el.prepend(container);
+				}
 			}
-			// editable wikis have a "header-actions" area
-			el.prepend(button);
+
+			container.appendChild(document.createElement("li")).appendChild(button)
+
 			if (isHidden) {
 				toggleSidebar();
 			}
@@ -64,13 +72,24 @@
 	}
 
 	function toggleSidebar(button) {
-		const sidebar = $(".wiki-rightbar")?.parentNode;
-		const wrapper = sidebar?.parentNode;
-		if (sidebar && wrapper) {
+		const sidebar = $(".Layout-sidebar") || $(".pr-2");
+		if (sidebar) {
 			const action = isHidden ? "remove" : "add";
 			button?.classList.toggle("selected", isHidden);
 			sidebar.style.display = isHidden ? "none" : "";
-			wrapper.classList[action]("Layout")
+
+			// have content expand to fill empty space
+			if (sidebar.className == "Layout-sidebar") {
+				sidebar.parentNode?.classList[action]("Layout");
+			} else {
+				let content = sidebar.previousSibling?.firstChild;
+				let value = isHidden ? "full" : "large";
+				content.setAttribute("data-width", value);
+
+				let article = $("article");
+				article?.classList.toggle("container-lg");
+			}
+
 			GM_setValue("sidebar-state", isHidden);
 		}
 	}

--- a/github-toggle-wiki-sidebar.user.js
+++ b/github-toggle-wiki-sidebar.user.js
@@ -64,14 +64,13 @@
 	}
 
 	function toggleSidebar(button) {
-		const sidebar = $(".wiki-rightbar");
+		const sidebar = $(".wiki-rightbar")?.parentNode;
 		const wrapper = sidebar?.parentNode;
 		if (sidebar && wrapper) {
 			const action = isHidden ? "remove" : "add";
 			button?.classList.toggle("selected", isHidden);
-			wrapper.style.display = isHidden ? "none" : "";
-			wrapper.classList[action]("has-rightbar");
-			wrapper.previousElementSibling?.classList[action]("col-md-9");
+			sidebar.style.display = isHidden ? "none" : "";
+			wrapper.classList[action]("Layout")
 			GM_setValue("sidebar-state", isHidden);
 		}
 	}


### PR DESCRIPTION
Modifies github-toggle-wiki-sidebar so that it applies to repo homepages as well as wiki pages. Also included is a fix that makes sure content expands into the (now) empty space correctly. 